### PR TITLE
Update sync-calendar.json

### DIFF
--- a/.homeycompose/flow/actions/sync-calendar.json
+++ b/.homeycompose/flow/actions/sync-calendar.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Sync calendars",
     "no": "Synkroniser kalenderene",
-    "nl": "Synchroniseer Kalender"
+    "nl": "Synchroniseer kalender"
   },
   "hint": {
     "en": "Will download new .ics files to update current events",


### PR DESCRIPTION
Typo changed "Kalender" to "kalender"