### PR TITLE
fix: cannot read length of null

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -231,10 +231,10 @@
                 if (calendars && calendars.length > 0) {
                     document.getElementById('uri-name').value = calendars[0].name;
                     document.getElementById('uri-uri').value = calendars[0].uri;
-                }
-
-                for (var i = 1; i < calendars.length; i++) {
-                    newCalendarItem(calendars[i].name, calendars[i].uri);
+                    
+                    for (var i = 1; i < calendars.length; i++) {
+                        newCalendarItem(calendars[i].name, calendars[i].uri);
+                    }
                 }
             }
 


### PR DESCRIPTION
the 'uris' setting will return null when the app is initially installed, opening the settings page will then show a popup "cannot read length of null".